### PR TITLE
fix spinlock refCounter oom when readonly key tx post

### DIFF
--- a/bcs/ledger/xledger/state/utxo/spin_lock.go
+++ b/bcs/ledger/xledger/state/utxo/spin_lock.go
@@ -51,6 +51,10 @@ func (rc *refCounter) Release(key string) int {
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
 	rc.ctMap[key]--
+	if rc.ctMap[key] == 0 {
+		delete(rc.ctMap, key)
+		return 0
+	}
 	return rc.ctMap[key]
 }
 


### PR DESCRIPTION
当只读key的交易post到节点时，spinlock 中没有将只读的key从map中删除，最终会导致oom。
see #379 