### PR TITLE
add account to peerID cache expiration

### DIFF
--- a/bcs/network/p2pv2/client.go
+++ b/bcs/network/p2pv2/client.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/patrickmn/go-cache"
 	"github.com/xuperchain/xupercore/lib/metrics"
 
 	xctx "github.com/xuperchain/xupercore/kernel/common/xcontext"
@@ -302,6 +301,7 @@ func (p *P2PServerV2) GetPeerIdByAccount(account string) (peer.ID, error) {
 		return "", fmt.Errorf("address error: %s, address=%s", err, value)
 	}
 
-	p.accounts.Set(key, peerID, cache.NoExpiration)
+	// 当前节点缓存 account=>peerID 1小时，dht 中默认是 36h，如果超过 36h 可能导致节点重启时不能参与共识。
+	p.accounts.Set(key, peerID, time.Hour*1)
 	return peerID, nil
 }


### PR DESCRIPTION
dht 中 record 默认缓存时间为36h，xupercore中一直缓存，最终导致节点重启后，在网络中 SearchValue 失败，最终导致不能同步区块。本次将 xupercore 中缓存改为1h，每隔1h去网络中查询并更新一次。